### PR TITLE
Updated badge, added BCDevExchange Search Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<a rel="delivery" href="https://github.com/BCDevExchange/docs/wiki/Project-States"><img alt="In production, but maybe in Alpha or Beta. Intended to persist and be supported." style="border-width:0" src="https://img.shields.io/badge/BCDevExchange-Delivery-brightgreen.svg" title="In production, but maybe in Alpha or Beta. Intended to persist and be supported." /></a>
-
+<a rel="Delivery" href="https://github.com/BCDevExchange/docs/blob/master/discussion/projectstates.md"><img alt="In production, but maybe in Alpha or Beta. Intended to persist and be supported." style="border-width:0" src="http://bcdevexchange.org/badge/3.svg" title="In production, but maybe in Alpha or Beta. Intended to persist and be supported." /></a> 
 ---
 
 # bcgroundwater

--- a/README.md
+++ b/README.md
@@ -70,3 +70,6 @@ If you would like to contribute to the package, please see our
 ### License
 
 Apache 2.0. See our [license](LICENSE) for more details.
+
+###### BCDevExchange Search Tags ######
+BCDevExchange-Resource, BCDevExchange-Delivery


### PR DESCRIPTION
Hi,

We've recently updated the badges (from Research and Discovery to Inspiration and Exploration, and changed the colour of the green of Delivery - see the updated scheme in https://github.com/BCDevExchange/docs/blob/master/discussion/projectstates.md), and  have updated this in your Readme. We're also exploring some functionality (in our lab) where we can return this repo into BCDevExchange's Resource Search via a GitHub API, by looking for certain tags in the Readme.md. I've added these tags to the bottom of your Readme to help make it discoverable. 

If you want your repo to be excluded from our query, you can remove the BCDevExchange Search Tags section, or the relevant tag (they are pretty self explanatory). 

Let us know if you have any questions,

Alex
